### PR TITLE
fix warning and update gravity logic

### DIFF
--- a/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/FlowLayout.java
+++ b/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/FlowLayout.java
@@ -15,6 +15,7 @@ public class FlowLayout extends ViewGroup
     protected List<List<View>> mAllViews = new ArrayList<List<View>>();
     protected List<Integer> mLineHeight = new ArrayList<Integer>();
     private String mGravity;
+    private List<View> lineViews = new ArrayList<>();
 
     public FlowLayout(Context context, AttributeSet attrs, int defStyle)
     {
@@ -105,13 +106,12 @@ public class FlowLayout extends ViewGroup
     {
         mAllViews.clear();
         mLineHeight.clear();
+        lineViews.clear();
 
         int width = getWidth();
 
         int lineWidth = 0;
         int lineHeight = 0;
-
-        List<View> lineViews = new ArrayList<View>();
 
         int cCount = getChildCount();
 

--- a/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/FlowLayout.java
+++ b/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/FlowLayout.java
@@ -12,18 +12,21 @@ import java.util.List;
 public class FlowLayout extends ViewGroup
 {
     private static final String TAG = "FlowLayout";
+    private static final int LEFT = -1;
+    private static final int CENTER = 0;
+    private static final int RIGHT = 1;
+
     protected List<List<View>> mAllViews = new ArrayList<List<View>>();
     protected List<Integer> mLineHeight = new ArrayList<Integer>();
-    private String mGravity;
+    protected List<Integer> mLineWidth = new ArrayList<Integer>();
+    private int mGravity;
     private List<View> lineViews = new ArrayList<>();
 
     public FlowLayout(Context context, AttributeSet attrs, int defStyle)
     {
         super(context, attrs, defStyle);
         TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.TagFlowLayout);
-        mGravity = ta.getString(R.styleable.TagFlowLayout_gravity);
-        if (mGravity == null)
-            mGravity = getResources().getString(R.string.gravity_left);
+        mGravity = ta.getInt(R.styleable.TagFlowLayout_gravity,LEFT);
         ta.recycle();
     }
 
@@ -129,6 +132,7 @@ public class FlowLayout extends ViewGroup
             {
                 mLineHeight.add(lineHeight);
                 mAllViews.add(lineViews);
+                mLineWidth.add(lineWidth);
 
                 lineWidth = 0;
                 lineHeight = childHeight + lp.topMargin + lp.bottomMargin;
@@ -141,7 +145,9 @@ public class FlowLayout extends ViewGroup
 
         }
         mLineHeight.add(lineHeight);
+        mLineWidth.add(lineWidth);
         mAllViews.add(lineViews);
+
 
 
         int left = getPaddingLeft();
@@ -154,7 +160,20 @@ public class FlowLayout extends ViewGroup
             lineViews = mAllViews.get(i);
             lineHeight = mLineHeight.get(i);
 
-            left = getStartLeft(lineViews);
+            // set gravity
+            int currentLineWidth = this.mLineWidth.get(i);
+            switch (this.mGravity){
+                case LEFT:
+                    left = getPaddingLeft();
+                    break;
+                case CENTER:
+                    left = (width - currentLineWidth)/2+getPaddingLeft();
+                    break;
+                case RIGHT:
+                    left = width - currentLineWidth + getPaddingLeft();
+                    break;
+            }
+
             for (int j = 0; j < lineViews.size(); j++)
             {
                 View child = lineViews.get(j);
@@ -179,35 +198,6 @@ public class FlowLayout extends ViewGroup
             top += lineHeight;
         }
 
-    }
-
-    private int getStartLeft(List<View> lineViews) {
-        int left = getPaddingLeft();
-
-        int needWidth = 0;
-        for (int j = 0; j < lineViews.size(); j++) {
-            View child = lineViews.get(j);
-            if (child.getVisibility() == View.GONE) {
-                continue;
-            }
-
-            MarginLayoutParams lp = (MarginLayoutParams) child
-                    .getLayoutParams();
-            needWidth += child.getMeasuredWidth() + lp.leftMargin
-                    + lp.rightMargin;
-        }
-
-        needWidth += getPaddingLeft() + getPaddingRight();
-        if (mGravity.equals(getResources().getString(R.string.gravity_center))) {
-            if (getMeasuredWidth() > needWidth) {
-                left += (getMeasuredWidth() - needWidth) / 2;
-            }
-        } else if (mGravity.equals(getResources().getString(R.string.gravity_right))) {
-            if (getMeasuredWidth() > needWidth) {
-                left += getMeasuredWidth() - needWidth;
-            }
-        }
-        return left;
     }
 
     @Override

--- a/flowlayout-lib/src/main/res/values/attrs.xml
+++ b/flowlayout-lib/src/main/res/values/attrs.xml
@@ -3,6 +3,10 @@
     <declare-styleable name="TagFlowLayout">
         <attr name="auto_select_effect" format="boolean"></attr>
         <attr name="max_select" format="integer"></attr>
-        <attr name="gravity" format="string"></attr>
+        <attr name="gravity">
+            <enum name="left" value="-1" />
+            <enum name="center" value="0" />
+            <enum name="right" value="1" />
+        </attr>
     </declare-styleable>
 </resources>

--- a/flowlayout/src/main/java/com/zhy/flowlayout/CategoryActivity.java
+++ b/flowlayout/src/main/java/com/zhy/flowlayout/CategoryActivity.java
@@ -15,7 +15,7 @@ public class CategoryActivity extends AppCompatActivity
 
     private String[] mTabTitles = new String[]
             {"Muli Selected", "Limit 3",
-                    "Event Test", "ScrollView Test","Single Choose"};
+                    "Event Test", "ScrollView Test","Single Choose","Gravity"};
 
 
     @Override
@@ -44,6 +44,8 @@ public class CategoryActivity extends AppCompatActivity
                         return new ScrollViewTestFragment();
                     case 4:
                         return new SingleChooseFragment();
+                    case 5:
+                        return GravityFragment.getOurInstance();
                     default:
                         return new EventTestFragment();
                 }

--- a/flowlayout/src/main/java/com/zhy/flowlayout/GravityFragment.java
+++ b/flowlayout/src/main/java/com/zhy/flowlayout/GravityFragment.java
@@ -1,0 +1,42 @@
+package com.zhy.flowlayout;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * Description：GravityFragment
+ * Created by：CaMnter
+ * Time：2015-12-25 16:11
+ */
+public class GravityFragment extends Fragment {
+
+    public static GravityFragment ourInstance;
+
+    public static GravityFragment getOurInstance() {
+        if (ourInstance == null) ourInstance = new GravityFragment();
+        return ourInstance;
+    }
+
+    private GravityFragment(){
+
+    }
+
+    private View self;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        if (this.self == null) {
+            this.self = inflater.inflate(R.layout.fragment_gravity_flow_layout, null);
+        }
+        if (this.self.getParent() != null) {
+            ViewGroup parent = (ViewGroup) this.self.getParent();
+            parent.removeView(this.self);
+        }
+        return this.self;
+    }
+}

--- a/flowlayout/src/main/res/layout/fragment_gravity_flow_layout.xml
+++ b/flowlayout/src/main/res/layout/fragment_gravity_flow_layout.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="gravity:left" />
+
+    <com.zhy.view.flowlayout.FlowLayout
+        android:id="@+id/left_fl"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        app:gravity="left">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Breath And Life"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Fallen"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Brand-new World"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Save you from anything"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+    </com.zhy.view.flowlayout.FlowLayout>
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="26dp"
+        android:text="gravity:center" />
+
+    <com.zhy.view.flowlayout.FlowLayout
+        android:id="@+id/center_fl"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        app:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Breath And Life"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Fallen"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Brand-new World"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Save you from anything"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+    </com.zhy.view.flowlayout.FlowLayout>
+
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="26dp"
+        android:text="gravity:right" />
+
+    <com.zhy.view.flowlayout.FlowLayout
+        android:id="@+id/right_fl"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        app:gravity="right">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Breath And Life"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Fallen"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Brand-new World"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="6dp"
+            android:layout_marginRight="6dp"
+            android:background="@drawable/normal_bg"
+            android:text="Save you from anything"
+            android:textColor="@drawable/text_color"
+            android:textSize="13sp" />
+
+    </com.zhy.view.flowlayout.FlowLayout>
+
+</LinearLayout>


### PR DESCRIPTION
您好，鸿洋。

几个月前，公司也有需要需要到FlowLayout，搜到你博客，并且用了你的FlowLayout，节约了我的开发时间，对此表示感谢。

后来有一些需求，就是对齐吧，当时您的博客上的代码还没gravity的设置，之后我在项目的FlowLayout做了升级。

1.首先是修复了一个warning，不知道您是否使用Android Studio，该warning
:Avoid object allocations during draw/layout operations 。是在onLayout里报错的，这里声明了一个lineViews属性来解决

2.attr里的gravity属性声明改为了
 <attr name="gravity">
            <enum name="left" value="-1" />
            <enum name="center" value="0" />
            <enum name="right" value="1" />
</attr>
更符合原生的gravity属性，快捷提示也提示了这三个属性值，
不担心取不到值，因为mGravity = ta.getInt(R.styleable.TagFlowLayout_gravity,LEFT);有默认值。

3.修改了set gravity的逻辑：
原来的getStartLeft 多走了一次for，个人认为没必要因为在：
for (int i = 0; i < lineNum; i++)的时候，每次都走行的逻辑，所以在这里可以给每行实现gravity逻辑了
int currentLineWidth = this.mLineWidth.get(i);
            switch (this.mGravity){
                case LEFT:
                    left = getPaddingLeft();
                    break;
                case CENTER:
                    left = (width - currentLineWidth)/2+getPaddingLeft();
                    break;
                case RIGHT:
                    left = width - currentLineWidth + getPaddingLeft();
                    break;
            }

4.加了一个GravityFragment，作为gravity的演示， 
