### PR TITLE
修复设置默认Tag时的崩溃问题

### DIFF
--- a/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/TagAdapter.java
+++ b/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/TagAdapter.java
@@ -2,6 +2,7 @@ package com.zhy.view.flowlayout;
 
 import android.view.View;
 
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -64,8 +65,9 @@ public abstract class TagAdapter<T>
     }
 
     public void notifyDataChanged()
-    {
-        mOnDataChangedListener.onChanged();
+    {   
+        if(mOnDataChangedListener != null)
+            mOnDataChangedListener.onChanged();
     }
 
     public T getItem(int position)


### PR DESCRIPTION
设置默认Tag时，如果不设置mOnDataChangedListener，则会造成空指针异常