### PR TITLE
fix tagview bug

### DIFF
--- a/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/TagFlowLayout.java
+++ b/flowlayout-lib/src/main/java/com/zhy/view/flowlayout/TagFlowLayout.java
@@ -139,6 +139,8 @@ public class TagFlowLayout extends FlowLayout implements TagAdapter.OnDataChange
                         dip2px(getContext(), 5));
                 tagViewContainer.setLayoutParams(lp);
             }
+            tagView.setLayoutParams(new FrameLayout.LayoutParams(tagView.getLayoutParams().width,
+                    tagView.getLayoutParams().height));
             tagViewContainer.addView(tagView);
             addView(tagViewContainer);
 


### PR DESCRIPTION
Android大部分机型中frameLayout可能会忽略子view的margin值。
但是部分机型上不会，例如华为，如果在xml中设置锅tagview的margin，在changeAdapter中会对这个margin进行拷贝，造成UI上两倍的margin效果，修改部分为只设置外层framelayout的margin，去掉子view的margin。